### PR TITLE
webpack config의 HtmlPlugin index.html 추가

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,9 @@ module.exports = {
     path: path.resolve(__dirname, './dist'),
     filename: 'index_bundle.js',
   },
-  plugins: [new HtmlWebpackPlugin()],
+  plugins: [new HtmlWebpackPlugin({
+    template: 'index.html',
+  })],
   module: {
     rules: [
       {


### PR DESCRIPTION
local에서 webpack-dev-server 실행시 index.html이 ./index.html이 아닌 ./dist/index.html 로 설정되는 문제 해결